### PR TITLE
No speed menu customization - disabled by default

### DIFF
--- a/TeenAstroSHC/SmartController.cpp
+++ b/TeenAstroSHC/SmartController.cpp
@@ -337,8 +337,18 @@ void SmartHandController::update()
     }
     else if (eventbuttons[1] == E_LONGPRESS || eventbuttons[1] == E_CLICK || eventbuttons[1] == E_LONGPRESSTART)
     {
+    #ifdef NO_SPEED_MENU
+      increaseSpeed(true);
+    #else
       menuSpeedRate();
+    #endif
     }
+    #ifdef NO_SPEED_MENU
+    else if (eventbuttons[2] == E_LONGPRESS || eventbuttons[2] == E_CLICK || eventbuttons[2] == E_LONGPRESSTART)
+    {
+      increaseSpeed(false);
+    }
+    #endif
     else if (eventbuttons[4] == E_LONGPRESS || eventbuttons[4] == E_CLICK || eventbuttons[4] == E_LONGPRESSTART)
     {
       menuTelSettings();

--- a/TeenAstroSHC/SmartController.h
+++ b/TeenAstroSHC/SmartController.h
@@ -73,6 +73,9 @@ private:
   void resetSHC();
   void menuTelAction();
   void menuSpeedRate();
+  #ifdef NO_SPEED_MENU
+  void increaseSpeed(bool increase);
+  #endif
   void menuReticule();
   void menuTrack();
 

--- a/TeenAstroSHC/SmartController_Tel_Actions.cpp
+++ b/TeenAstroSHC/SmartController_Tel_Actions.cpp
@@ -22,6 +22,33 @@ void SmartHandController::menuSpeedRate()
   buttonPad.setControlerMode();
 }
 
+#ifdef NO_SPEED_MENU
+void SmartHandController::increaseSpeed(bool increase)
+{
+  //buttonPad.setMenuMode();
+  char* string_list_Speed = T_GUIDE "\n" T_SLOW "\n" T_MEDIUM "\n" T_FAST "\n" T_MAX;
+  static unsigned char current_speed = 3;
+  ta_MountStatus.updateMount();
+  TeenAstroMountStatus::GuidingRate cur_GR = ta_MountStatus.getGuidingRate();
+  if (cur_GR == TeenAstroMountStatus::GuidingRate::UNKNOW)
+    return;
+  current_speed = static_cast<unsigned char>(cur_GR);
+  char cmd[5] = ":Rn#";
+  if (increase && cur_GR < TeenAstroMountStatus::MAX )
+  {
+    
+    cmd[2] = '0' + current_speed + 1;
+    SetLX200(cmd);
+  }
+  else if (!increase && cur_GR > TeenAstroMountStatus::GUIDING )
+  {
+    cmd[2] = '0' + current_speed - 1;
+    SetLX200(cmd);
+  }
+  //buttonPad.setControlerMode();
+}
+#endif
+
 void SmartHandController::menuTelAction()
 {
   buttonPad.setMenuMode();

--- a/libraries/TeenAstoCustomizations/TeenAstoCustomizations.h
+++ b/libraries/TeenAstoCustomizations/TeenAstoCustomizations.h
@@ -20,3 +20,7 @@
 
 // Uncomment to keep tracking on after meridian when far from Pole
 //#define keepTrackingOnWhenFarFromPole
+
+// Uncomment to enable quick speed change
+// by SHC Shift+N / Shift+S buttons
+//#define NO_SPEED_MENU


### PR DESCRIPTION
By editing TeenAstroCustomization the user can customize SHC to have no speed menu: Shift+N / Shift+S will we used to increase/decrease moving speed.

In case of further features that will require Shift+S for a new menu, this customization can still be kept and adapted (Shift+N will increase moving speed or, if current speed is already at max, switch to minimum speed).

The feature is disabled by default.