### PR TITLE
Fix alignment error report by SHC

### DIFF
--- a/TeenAstroSHC/Actions_Tel.cpp
+++ b/TeenAstroSHC/Actions_Tel.cpp
@@ -471,7 +471,18 @@ SmartHandController::MENU_RESULT SmartHandController::menuAlignment()
       }
       break;
     case 5:
-      char err_az[15] = { "?" };
+      char text[20];
+      if (GetLX200(":AE#", text, sizeof(text)) == LX200_VALUEGET)
+      {
+        strcat(text, " " T_DEG);
+        DisplayMessage("Alignment error:", text, -1);
+      }
+      else
+        DisplayMessage("Alignment error:", "?", -1);
+      break;
+        
+    
+/*      char err_az[15] = { "?" };
       char err_alt[15] = { "?" };
       char err_pol[15] = { "?" };
       if (
@@ -486,6 +497,7 @@ SmartHandController::MENU_RESULT SmartHandController::menuAlignment()
       else
         DisplayMessage("Alignment error:", "?", -1);
       break;
+*/
     }
   }
 }


### PR DESCRIPTION
Hi Charles,
I adapted the code to fix alignment report by SHC.
I commented my previous code (working with older releases) because I think it's worth reporting altitude and azimuth components of the error on next source updates. I don't know if my old code (to show altitude and azimuth values) is to be adapted because of your changes affecting coordinates.

Thanks again and Clear Skies!
Armando 