### PR TITLE
CommandReplyLength fix and ASCOM homing

### DIFF
--- a/TeenAstroASCOM_V7/TeenAstroASCOM_V7/TelescopeDriver/TelescopeHardware.cs
+++ b/TeenAstroASCOM_V7/TeenAstroASCOM_V7/TelescopeDriver/TelescopeHardware.cs
@@ -866,8 +866,8 @@ namespace ASCOM.TeenAstro.Telescope
     {
       get
       {
-        LogMessage("CanFindHome", "Get - " + false.ToString());
-        return false;
+        LogMessage("Get CanFindHome", HasMotors.ToString());
+        return HasMotors;
       }
     }
 
@@ -1220,8 +1220,30 @@ namespace ASCOM.TeenAstro.Telescope
     /// </summary>
     internal static void FindHome()
     {
-      LogMessage("FindHome", "Not implemented");
-      throw new MethodNotImplementedException("FindHome");
+      if (CanFindHome)
+      {
+        if (AtHome)
+        {
+          LogMessage("FindHome", "Already at home");
+          return;
+        }
+        string cmd = "hC";
+        if (CommandBoolSingleChar(cmd))
+        {
+          slewingHintUntilUtc = DateTime.UtcNow.AddSeconds(2);
+          ForceGXASCacheRefresh();
+          LogMessage("FindHome", "Started");
+        }
+        else
+        {
+          LogMessage("FindHome", "failed");
+          throw new ASCOM.DriverException("FindHome has failed");
+        }
+      }
+      else
+      {
+        throw new ASCOM.MethodNotImplementedException("FindHome");
+      }
     }
 
     /// <summary>

--- a/libraries/TeenAstroCommandDef/src/CommandReplyLength.h
+++ b/libraries/TeenAstroCommandDef/src/CommandReplyLength.h
@@ -140,7 +140,7 @@ inline int getExpectedReplyLength(const char* command)
   if (strcmp(command, ":GXT0#") == 0) return 8;
   if (strcmp(command, ":GXT1#") == 0) return 8;
   if (strcmp(command, ":GXT2#") == 0) return 16;
-  if (strcmp(command, ":GXT3#") == 0) return 8;
+  if (strcmp(command, ":GXT3#") == 0) return 9;
   if (strcmp(command, ":GXlX#") == 0) return 8;
   if (strcmp(command, ":GXrg#") == 0) return 4;
   if (strcmp(command, ":GXrp#") == 0) return 4;


### PR DESCRIPTION
:GXT3# may return negative hour angles (e.g. -00:05:49), which are 9 characters long. The current fixed expected length of 8 causes sendReceive() to reject valid replies. Either set the expected length to 9 or mark this command as variable-length.